### PR TITLE
[v0.5.1]: Per minor update on IDF-v5.3 branch

### DIFF
--- a/components/esp_wifi_remote/.cz.yaml
+++ b/components/esp_wifi_remote/.cz.yaml
@@ -3,6 +3,6 @@ commitizen:
   bump_message: 'bump(wifi_remote): $current_version -> $new_version'
   pre_bump_hooks: python ../../ci/changelog.py esp_wifi_remote
   tag_format: wifi_remote-v$version
-  version: 0.5.0
+  version: 0.5.1
   version_files:
   - idf_component.yml

--- a/components/esp_wifi_remote/CHANGELOG.md
+++ b/components/esp_wifi_remote/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [0.5.1](https://github.com/espressif/esp-wifi-remote/commits/wifi_remote-v0.5.1)
+
+### Bug Fixes
+
+- Update per IDF-v5.5 espressif/esp-idf@e65acc9510 ([cb6bf06](https://github.com/espressif/esp-wifi-remote/commit/cb6bf06))
+- Update per espressif/esp-idf@87bb09d746 ([2dfc63c](https://github.com/espressif/esp-wifi-remote/commit/2dfc63c))
+
 ## [0.5.0](https://github.com/espressif/esp-wifi-remote/commits/wifi_remote-v0.5.0)
 
 ### Features

--- a/components/esp_wifi_remote/idf_component.yml
+++ b/components/esp_wifi_remote/idf_component.yml
@@ -1,4 +1,4 @@
-version: 0.5.0
+version: 0.5.1
 url: https://github.com/espressif/esp-wifi-remote
 description: Utility wrapper for esp_wifi functionality on remote targets
 dependencies:

--- a/components/esp_wifi_remote/idf_v5.3/Kconfig.wifi.in
+++ b/components/esp_wifi_remote/idf_v5.3/Kconfig.wifi.in
@@ -244,7 +244,10 @@
             range 6 32
             default 32
             help
-                Set the number of WiFi management short buffer.
+                Set the maximum number of Wi-Fi management short buffers. These buffers are dynamically allocated,
+                with their size determined by the length of the management packet to be sent. When a management
+                packet is less than 64 bytes, the Wi-Fi driver classifies it as a short management packet and
+                assigns it to one of these buffers.
 
         config ESP_WIFI_IRAM_OPT
             bool "WiFi IRAM speed optimization"

--- a/components/esp_wifi_remote/idf_v5.5/Kconfig.wifi.in
+++ b/components/esp_wifi_remote/idf_v5.5/Kconfig.wifi.in
@@ -5,8 +5,8 @@
             int "Max number of WiFi static RX buffers"
             range 2 25 if !SLAVE_SOC_WIFI_HE_SUPPORT
             range 2 128 if SLAVE_SOC_WIFI_HE_SUPPORT
-            default 10 if !SPIRAM_TRY_ALLOCATE_WIFI_LWIP
-            default 16 if SPIRAM_TRY_ALLOCATE_WIFI_LWIP
+            default 10 if !(SPIRAM_TRY_ALLOCATE_WIFI_LWIP && !SPIRAM_IGNORE_NOTFOUND)
+            default 16 if (SPIRAM_TRY_ALLOCATE_WIFI_LWIP && !SPIRAM_IGNORE_NOTFOUND)
             help
                 Set the number of WiFi static RX buffers. Each buffer takes approximately 1.6KB of RAM.
                 The static rx buffers are allocated when esp_wifi_init is called, they are not freed
@@ -57,7 +57,7 @@
                 bool "Static"
             config ESP_WIFI_DYNAMIC_TX_BUFFER
                 bool "Dynamic"
-                depends on !SPIRAM_USE_MALLOC
+                depends on !(SPIRAM_TRY_ALLOCATE_WIFI_LWIP && !SPIRAM_IGNORE_NOTFOUND)
         endchoice
 
         config ESP_WIFI_TX_BUFFER_TYPE
@@ -82,8 +82,8 @@
 
         config ESP_WIFI_CACHE_TX_BUFFER_NUM
             int "Max number of WiFi cache TX buffers"
-            depends on SPIRAM
-            range 16 128
+            depends on (SPIRAM_TRY_ALLOCATE_WIFI_LWIP && !SPIRAM_IGNORE_NOTFOUND)
+            range 0 128
             default 32
             help
                 Set the number of WiFi cache TX buffer number.
@@ -180,8 +180,8 @@
             depends on ESP_WIFI_AMPDU_RX_ENABLED
             range 2 32 if !SLAVE_SOC_WIFI_HE_SUPPORT
             range 2 64 if SLAVE_SOC_WIFI_HE_SUPPORT
-            default 6 if !SPIRAM_TRY_ALLOCATE_WIFI_LWIP
-            default 16 if SPIRAM_TRY_ALLOCATE_WIFI_LWIP
+            default 6 if !(SPIRAM_TRY_ALLOCATE_WIFI_LWIP && !SPIRAM_IGNORE_NOTFOUND)
+            default 16 if (SPIRAM_TRY_ALLOCATE_WIFI_LWIP && !SPIRAM_IGNORE_NOTFOUND)
             help
                 Set the size of WiFi Block Ack RX window. Generally a bigger value means higher throughput and better
                 compatibility but more memory. Most of time we should NOT change the default value unless special
@@ -192,7 +192,7 @@
 
         config ESP_WIFI_AMSDU_TX_ENABLED
             bool "WiFi AMSDU TX"
-            depends on SPIRAM
+            depends on (ESP_WIFI_CACHE_TX_BUFFER_NUM >= 2)
             default n
             help
                 Select this option to enable AMSDU TX feature


### PR DESCRIPTION
* overnight cron-job failing on compatibility checks: https://github.com/espressif/esp-wifi-remote/actions/runs/11564722957
- [x] Draft until IDF v5.5 gets published (CI won't pass)

## [0.5.1](https://github.com/espressif/esp-wifi-remote/commits/wifi_remote-v0.5.1)

### Bug Fixes

- Update per IDF-v5.5 espressif/esp-idf@e65acc9510 ([cb6bf06](https://github.com/espressif/esp-wifi-remote/commit/cb6bf06))
- Update per IDF-v5.3 espressif/esp-idf@87bb09d746 ([2dfc63c](https://github.com/espressif/esp-wifi-remote/commit/2dfc63c))

