### PR TITLE
[bump]: wifi-remote -> 0.5.2

### DIFF
--- a/components/esp_wifi_remote/.cz.yaml
+++ b/components/esp_wifi_remote/.cz.yaml
@@ -3,6 +3,6 @@ commitizen:
   bump_message: 'bump(wifi_remote): $current_version -> $new_version'
   pre_bump_hooks: python ../../ci/changelog.py esp_wifi_remote
   tag_format: wifi_remote-v$version
-  version: 0.5.1
+  version: 0.5.2
   version_files:
   - idf_component.yml

--- a/components/esp_wifi_remote/CHANGELOG.md
+++ b/components/esp_wifi_remote/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## [0.5.2](https://github.com/espressif/esp-wifi-remote/commits/wifi_remote-v0.5.2)
+
+### Features
+
+- Add wifi-remote target test ([f413031](https://github.com/espressif/esp-wifi-remote/commit/f413031))
+- Make UART port number configurable ([c088f44](https://github.com/espressif/esp-wifi-remote/commit/c088f44))
+
+### Bug Fixes
+
+- Fix script to skip preview targets missing config.caps ([469dbaf](https://github.com/espressif/esp-wifi-remote/commit/469dbaf))
+- Update v5.4 per espressif/esp-idf@e65acc95109 ([c2110d6](https://github.com/espressif/esp-wifi-remote/commit/c2110d6))
+
 ## [0.5.1](https://github.com/espressif/esp-wifi-remote/commits/wifi_remote-v0.5.1)
 
 ### Bug Fixes

--- a/components/esp_wifi_remote/idf_component.yml
+++ b/components/esp_wifi_remote/idf_component.yml
@@ -1,4 +1,4 @@
-version: 0.5.1
+version: 0.5.2
 url: https://github.com/espressif/esp-wifi-remote
 description: Utility wrapper for esp_wifi functionality on remote targets
 dependencies:


### PR DESCRIPTION
## [0.5.2](https://github.com/espressif/esp-wifi-remote/commits/wifi_remote-v0.5.2)

### Features

- Add wifi-remote target test ([f413031](https://github.com/espressif/esp-wifi-remote/commit/f413031))
- Make UART port number configurable ([c088f44](https://github.com/espressif/esp-wifi-remote/commit/c088f44))

### Bug Fixes

- Fix script to skip preview targets missing config.caps ([469dbaf](https://github.com/espressif/esp-wifi-remote/commit/469dbaf))
- Update v5.4 per espressif/esp-idf@e65acc95109 ([c2110d6](https://github.com/espressif/esp-wifi-remote/commit/c2110d6))

