### PR TITLE
Fix: Inject wifi headers only if no wifi/wifi-host

### DIFF
--- a/components/esp_wifi_remote/.cz.yaml
+++ b/components/esp_wifi_remote/.cz.yaml
@@ -3,6 +3,6 @@ commitizen:
   bump_message: 'bump(wifi_remote): $current_version -> $new_version'
   pre_bump_hooks: python ../../ci/changelog.py esp_wifi_remote
   tag_format: wifi_remote-v$version
-  version: 0.10.0
+  version: 0.10.1
   version_files:
   - idf_component.yml

--- a/components/esp_wifi_remote/CHANGELOG.md
+++ b/components/esp_wifi_remote/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.10.1](https://github.com/espressif/esp-wifi-remote/commits/wifi_remote-v0.10.1)
+
+### Bug Fixes
+
+- Inject wifi headers only if no wifi/wifi-host ([f13a99a](https://github.com/espressif/esp-wifi-remote/commit/f13a99a))
+
 ## [0.10.0](https://github.com/espressif/esp-wifi-remote/commits/wifi_remote-v0.10.0)
 
 ### Features

--- a/components/esp_wifi_remote/CMakeLists.txt
+++ b/components/esp_wifi_remote/CMakeLists.txt
@@ -51,9 +51,11 @@ target_sources(${COMPONENT_LIB}             ${TARGET_SOURCE_TYPE}  ${src_wifi_re
                                                                    ${src_wifi_with_remote}
                                                                    ${wifi_sources})
 
-# Update wifi include directories to prepend the injected dir with modified headers supporting SLAVE capability
-get_target_property(original_wifi_dirs ${wifi} INTERFACE_INCLUDE_DIRECTORIES)
-set(updated_wifi_dirs "${IDF_VER_DIR}/include/injected" ${original_wifi_dirs})
-set_target_properties(${wifi} PROPERTIES INTERFACE_INCLUDE_DIRECTORIES "${updated_wifi_dirs}")
+if(NOT CONFIG_ESP_WIFI_ENABLED AND NOT CONFIG_ESP_HOST_WIFI_ENABLED)
+    # Update wifi include directories to prepend the injected dir with modified headers supporting SLAVE capability
+    get_target_property(original_wifi_dirs ${wifi} INTERFACE_INCLUDE_DIRECTORIES)
+    set(updated_wifi_dirs "${IDF_VER_DIR}/include/injected" ${original_wifi_dirs})
+    set_target_properties(${wifi} PROPERTIES INTERFACE_INCLUDE_DIRECTORIES "${updated_wifi_dirs}")
+endif()
 
 target_link_libraries(${wifi} PUBLIC ${COMPONENT_LIB})

--- a/components/esp_wifi_remote/idf_component.yml
+++ b/components/esp_wifi_remote/idf_component.yml
@@ -1,4 +1,4 @@
-version: 0.10.0
+version: 0.10.1
 url: https://github.com/espressif/esp-wifi-remote
 description: Utility wrapper for esp_wifi functionality on remote targets
 dependencies:


### PR DESCRIPTION
Allow wifi-remote build with standard wifi or wifi-host