### PR TITLE
Fix warning about config consistency of target vs. slave

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,7 +35,7 @@ jobs:
             key: ${{ matrix.idf_ver }}
       - name: Build ${{ matrix.test.app }} with IDF-${{ matrix.idf_ver }}
         env:
-          EXPECTED_WARNING: "DeprecationWarning: 'MultiCommand' is deprecated and will be removed\ndependencies ESP_PHY_ENABLED with value n\nCryptographyDeprecationWarning: Parsed a serial number which wasn't positive"
+          EXPECTED_WARNING: "DeprecationWarning: 'MultiCommand' is deprecated and will be removed\nCryptographyDeprecationWarning: Parsed a serial number which wasn't positive"
         shell: bash
         run: |
           . ${IDF_PATH}/export.sh
@@ -68,7 +68,7 @@ jobs:
           path: protocols
       - name: Build ${{ matrix.example.app }} with IDF-${{ matrix.idf_ver }}
         env:
-          EXPECTED_WARNING: "DeprecationWarning: 'MultiCommand' is deprecated and will be removed\nWarning: The smallest app partition is nearly full\ndependencies ESP_PHY_ENABLED with value n\nCryptographyDeprecationWarning: Parsed a serial number which wasn't positive"
+          EXPECTED_WARNING: "DeprecationWarning: 'MultiCommand' is deprecated and will be removed\nWarning: The smallest app partition is nearly full\nCryptographyDeprecationWarning: Parsed a serial number which wasn't positive"
         shell: bash
         run: |
           . ${IDF_PATH}/export.sh


### PR DESCRIPTION
Fixes warning:
```
warning: ESP_PHY_IRAM_OPT (defined at /home/david/dev/idf/components/esp_phy/Kconfig:181) has direct dependencies ESP_PHY_ENABLED with value n, but is currently being y-selected by the following symbols:
 - WIFI_RMT_SLP_IRAM_OPT (defined at /home/david/dev/idf/examples/protocols/mqtt/tcp/managed_components/espressif__esp_wifi_remote/./idf_v5.5/Kconfig.wifi.in:321), with value y, direct dependencies ESP_WIFI_REMOTE_ENABLED (value: y), and select condition ESP_WIFI_REMOTE_ENABLED (value: y)
```