### PR TITLE
bump(wifi_remote): 1.6.3 -> 1.6.4

### DIFF
--- a/components/esp_wifi_remote/.cz.yaml
+++ b/components/esp_wifi_remote/.cz.yaml
@@ -3,6 +3,6 @@ commitizen:
   bump_message: 'bump(wifi_remote): $current_version -> $new_version'
   pre_bump_hooks: python ../../ci/changelog.py esp_wifi_remote
   tag_format: wifi_remote-v$version
-  version: 1.6.3
+  version: 1.6.4
   version_files:
   - idf_component.yml

--- a/components/esp_wifi_remote/CHANGELOG.md
+++ b/components/esp_wifi_remote/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## [1.6.4](https://github.com/espressif/esp-wifi-remote/commits/wifi_remote-v1.6.4)
+
+### Bug Fixes
+
+- Regenerate v6.0 injected wifi types header ([ae98a2f](https://github.com/espressif/esp-wifi-remote/commit/ae98a2f))
+- Regenerate v5.3 Kconfig for roaming-app select ([f9db751](https://github.com/espressif/esp-wifi-remote/commit/f9db751))
+- Revert esp-hosted restriction (~v3.0) ([5811ce4](https://github.com/espressif/esp-wifi-remote/commit/5811ce4))
+
+### Updated
+
+- ci: use esp_hosted wifi/sta/cp example (slave dropped in v3.x) ([a76c0da](https://github.com/espressif/esp-wifi-remote/commit/a76c0da))
+
 ## [1.6.3](https://github.com/espressif/esp-wifi-remote/commits/wifi_remote-v1.6.3)
 
 ### Bug Fixes

--- a/components/esp_wifi_remote/idf_component.yml
+++ b/components/esp_wifi_remote/idf_component.yml
@@ -1,4 +1,4 @@
-version: 1.6.3
+version: 1.6.4
 url: https://github.com/espressif/esp-wifi-remote
 description: Utility wrapper for esp_wifi functionality on remote targets
 dependencies:

--- a/components/esp_wifi_remote/include/esp_wifi_remote_version.h
+++ b/components/esp_wifi_remote/include/esp_wifi_remote_version.h
@@ -15,7 +15,7 @@
  /** Minor version number (x.X.x) */
  #define ESP_WIFI_REMOTE_VERSION_MINOR   6
  /** Patch version number (x.x.X) */
- #define ESP_WIFI_REMOTE_VERSION_PATCH   3
+ #define ESP_WIFI_REMOTE_VERSION_PATCH   4
 
  /**
   * Macro to convert WIFI_REMOTE version number into an integer


### PR DESCRIPTION
1.6.4
Bug Fixes
- Regenerate v6.0 injected wifi types header (ae98a2f)
- Regenerate v5.3 Kconfig for roaming-app select (f9db751)
- Revert esp-hosted restriction (~v3.0) (5811ce4) Updated
- ci: use esp_hosted wifi/sta/cp example (slave dropped in v3.x) (a76c0da)

<!--
- Read and understand the project style guidelines (`CONTRIBUTION.md`).
- For Work In Progress Pull Requests, please use the Draft PR feature. See https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
- For a timely review/response, please avoid force-pushing additional commits if your PR has already received reviews or comments.
- Include screenshots for any CLI or UI changes.
- Keep PRs as small as possible; large PRs are difficult to review.
-->

## Description

<!--
- Please include a summary of the changes and the related issue.
- Also include the motivation (why this change) and context.
-->

<!-- 
- If you want to insert images (screenshots, diagrams, etc.), please format them:
    Bad link to the image (not formatted):   ![image](https://github.com/user-attachments/assets/ad3383cd-8f38-4d06-9ecf-3305e299307d)~~
    Good link to the image (formatted):       <img src="https://github.com/user-attachments/assets/ad3383cd-8f38-4d06-9ecf-3305e299307d" width=500px>
-->

## Related

<!--
- Use this format to link issue numbers: Fixes #123 - https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue-using-a-keyword
- Mention any other PRs related to this one.
- If there is related documentation, add the link here.
- If there is a public chat where changes in this PR were initiated, you can include the link here.
-->

## Testing

<!--
- Explain how you tested your change or new feature.
- If you tested changes in a clean environment (Docker container, new virtualenv, fresh Virtual Machine), state it here.
-->

---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [ ] 🚨 This PR does not introduce breaking changes.
- [ ] All CI checks (GH Actions) pass.
- [ ] Documentation is updated as needed.
- [ ] Tests are updated or added as necessary.
- [ ] Code is well-commented, especially in complex areas.
- [ ] Git history is clean — commits are squashed to the minimum necessary.
